### PR TITLE
RPC updates

### DIFF
--- a/pyacq/core/rpc.py
+++ b/pyacq/core/rpc.py
@@ -86,7 +86,7 @@ class RPCClientSocket(object):
         cmd = {'action': action, 'call_id': call_id,
                'args': args, 'kwds': kwds}
         cmd = json.dumps(cmd).encode()
-        print("SEND:", name, cmd)
+        #print("SEND:", name, cmd)
         self.socket.send_multipart([name, cmd])
         fut = Future(self, call_id)
         self.futures[call_id] = fut
@@ -126,7 +126,7 @@ class RPCClientSocket(object):
             fut = self.futures[call_id]
             if msg['error'] is not None:
                 exc = RemoteCallException(*msg['error'])
-                print("GOT EXC:", exc)
+                #print("GOT EXC:", exc)
                 fut.set_exception(exc)
             else:
                 fut.set_result(msg['rval'])
@@ -199,7 +199,7 @@ class RPCServer(object):
         self._socket.setsockopt(zmq.IDENTITY, self._name)
         self._socket.bind(addr)
         self._closed = False
-        print("START SERVER:", self._name)
+        #print("START SERVER:", self._name)
 
     def _process_one(self):
         """Read one message from the remote client and invoke the requested
@@ -209,9 +209,7 @@ class RPCServer(object):
         error message.
         """
         name = self._socket.recv()
-        print("RECV:", name)
         msg = self._socket.recv_json()
-        print("RECV:", msg)
         if msg['action'] == 'call':
             method, args = msg['args'][0], msg['args'][1:]
             kwds = msg['kwds']
@@ -234,11 +232,10 @@ class RPCServer(object):
                     self._send_result(name, call_id, error=(exc[0].__name__, exc_str))
         
     def _send_result(self, name, call_id, rval=None, error=None):
-        print("RESULT:", name, call_id, rval, error)
-        self._socket.send(name)
-        self._socket.send_json({'action': 'return', 'call_id': call_id,
-                                'rval': rval, 'error': error})
-        print("  (sent)")
+        #print("RESULT:", name, call_id, rval, error)
+        result = {'action': 'return', 'call_id': call_id,
+                  'rval': rval, 'error': error}
+        self._socket.send_multipart([name, json.dumps(result).encode()])
 
     def close(self):
         """Close this RPC server.

--- a/pyacq/core/rpc.py
+++ b/pyacq/core/rpc.py
@@ -8,14 +8,14 @@ RPC implemented over zmq sockets.
 
 """
 
-import zmq
-import random
+import os
 import sys
 import time
 import weakref
 import json
 import concurrent.futures
 import traceback
+import zmq
 
 
 class RemoteCallException(Exception):
@@ -29,7 +29,13 @@ class RemoteCallException(Exception):
 
 
 class Future(concurrent.futures.Future):
-    # todo: should we use concurrent.Future for this?
+    """Represents a return value from a remote procedure call that has not
+    yet arrived.
+    
+    Use `done()` to determine whether the return value (or an error message)
+    has arrived, and `result()` to get the return value (or raise an
+    exception).
+    """
     def __init__(self, socket, call_id):
         concurrent.futures.Future.__init__(self)
         self.socket = socket
@@ -44,19 +50,37 @@ class Future(concurrent.futures.Future):
 
 
 class RPCClientSocket(object):
-    def __init__(self, addr='tcp://*:5152'):
+    """A single socket for connecting to multiple RPC servers.
+    
+    This class should only be used to create RPCClient instances using
+    `get_client()`.
+    """
+    def __init__(self):
         self.socket = zmq.Context.instance().socket(zmq.ROUTER)
-        self.socket.bind(addr)
+        self._name = ('%d-%d' % (os.getpid(), id(self))).encode()
+        self.socket.setsockopt(zmq.IDENTITY, self._name)
         self.clients = {}
         self.next_call_id = 0
         self.futures = weakref.WeakValueDictionary()
         
-    def get_client(self, name):
-        if name not in self.clients:
-            self.clients[name] = RPCClient(name, self)
-        return self.clients[name]
+    def connect(self, addr):
+        """Conncet the socket to an RPCServer address.
+        
+        May connect to multiple servers.
+        """
+        self.socket.connect(addr)
     
     def send(self, name, action, *args, **kwds):
+        """Send a request to the remote process.
+        
+        Parameters
+        ----------
+        name : bytes
+            The remote process's identifier string
+        action : str
+            The action to invoke on the remote process. For now, the only
+            supported action is 'call'.
+        """
         call_id = self.next_call_id
         self.next_call_id += 1
         cmd = {'action': action, 'call_id': call_id,
@@ -73,25 +97,33 @@ class RPCClientSocket(object):
         """
         while True:
             try:
-                ident = self.socket.recv(zmq.NOBLOCK)
+                name = self.socket.recv(zmq.NOBLOCK)
                 msg = self.socket.recv_json()
-                self._process_msg(ident, msg)
+                self._process_msg(name, msg)
             except zmq.error.Again:
                 break  # no messages left
 
     def process_until_future(self, future, timeout=None):
-        """Process all incoming messages until receiving a result for *future*. 
+        """Process all incoming messages until receiving a result for *future*.
         """
         while not future.done():
             # wait patiently with blocking calls.
             # TODO: implement timeout
-            ident = self.socket.recv()
+            name = self.socket.recv()
             msg = self.socket.recv_json()
-            self._process_msg(ident, msg)
+            self._process_msg(name, msg)
 
-    def _process_msg(self, ident, msg):
+    def _process_msg(self, name, msg):
+        """Handle one message received from the remote process.
+        
+        This takes care of assigning return values or exceptions to existing
+        Future instances.
+        """
         if msg['action'] == 'return':
-            fut = self.futures[msg['call_id']]
+            call_id = msg['call_id']
+            if call_id not in self.futures:
+                return
+            fut = self.futures[call_id]
             if msg['error'] is not None:
                 exc = RemoteCallException(*msg['error'])
                 #print("GOT EXC:", exc)
@@ -101,33 +133,67 @@ class RPCClientSocket(object):
     
 
 class RPCClient(object):
-    def __init__(self, name, socket):
-        self.name = name.encode()
-        self.socket = socket
+    """Connection to an RPC server.
+    
+    This class is a proxy for methods provided by the remote server. It is
+    meant to be used by accessing and calling remote procedure names::
+    
+        client = RPCClient('tcp://localhost:5274')
+        future = client.my_remote_procedure_name(...)
+        result = future.result()
+        
+    Parameters
+    ----------
+    name : bytes
+        The identifier used by the remote server.
+    addr : URL
+        Address of RPC server to connect to.
+    socket : None or RPCClientSocket
+        Optional RPCClientSocket object. Used to allow multiple RPCClients to
+        share a single zmq socket.
+    """
+    def __init__(self, name, addr, socket=None):
+        if socket is None:
+            socket = RPCClientSocket()
+        socket.connect(addr)
+        self._name = name
+        self._socket = socket
+        self._methods = {}
         
     def __getattr__(self, name):
-        return self.get_method_proxy(name)
+        return self._methods.setdefault(name, RPCMethod(self, name))
     
-    def get_method_proxy(self, name):
-        return RPCMethod(self, name)
-    
-    def call_method(self, method_name, *args, **kwds):
-        return self.socket.send(self.name, 'call', method_name, *args, **kwds)
+    def _call_method(self, method_name, *args, **kwds):
+        return self._socket.send(self._name, 'call', method_name, *args, **kwds)
 
     
 class RPCMethod(object):
+    """A proxy to a single remote procedure.
+    
+    Calling this object invokes the remote procedure and returns a Future
+    instance.
+    """
     def __init__(self, client, method):
         self.client = client
         self.method = method
         
     def __call__(self, *args, **kwds):
-        return self.client.call_method(self.method, *args, **kwds)
+        return self.client._call_method(self.method, *args, **kwds)
 
 
 
 class RPCServer(object):
-    def __init__(self, name, addr='tcp://localhost:5152'):
-        self._name = name.encode()
+    """An RPC server abstract class.
+    
+    Subclasses must define any extra methods that may be called by the client.
+    
+    Parameters
+    ----------
+    addr : URL
+        Address for RPC server to bind to.
+    """
+    def __init__(self, addr):
+        self._name = '%d-%d' % (os.getpid(), id(self)).encode()
         self._socket = zmq.Context.instance().socket(zmq.DEALER)
         self._socket.setsockopt(zmq.IDENTITY, self._name)
         self._socket.connect(addr)
@@ -135,11 +201,19 @@ class RPCServer(object):
         #print("START SERVER:", self._name)
 
     def _process_one(self):
+        """Read one message from the remote client and invoke the requested
+        action.
+        
+        This method sends back to the client either the return value or an
+        error message.
+        """
+        name = self._socket.recv()
         msg = self._socket.recv_json()
         if msg['action'] == 'call':
+            method, args = msg['args'][0], msg['args'][1:]
+            kwds = msg['kwds']
+            ret = kwds.pop('_return', True)
             try:
-                method, args = msg['args'][0], msg['args'][1:]
-                kwds = msg['kwds']
                 call_id = msg['call_id']
                 fn = getattr(self, method)
                 if len(kwds) == 0:
@@ -148,60 +222,27 @@ class RPCServer(object):
                     rval = fn(*args)
                 else:
                     rval = fn(*args, **kwds)
-                self._send_result(call_id, rval=rval)
+                if ret:
+                    self._send_result(name, call_id, rval=rval)
             except:
                 exc = sys.exc_info()
                 exc_str = traceback.format_exception(*exc)
-                self._send_result(call_id, error=(exc[0].__name__, exc_str))
+                if ret:
+                    self._send_result(name, call_id, error=(exc[0].__name__, exc_str))
         
-    def _send_result(self, call_id, rval=None, error=None):
+    def _send_result(self, name, call_id, rval=None, error=None):
         #print("RESULT:", call_id, rval, error)
+        self._socket.send(name)
         self._socket.send_json({'action': 'return', 'call_id': call_id,
                                 'rval': rval, 'error': error})
 
     def close(self):
+        """Close this RPC server.
+        """
         self._closed = True
         self.socket.close()
 
     def running(self):
+        """Boolean indicating whether the server is still running.
+        """
         return not self._closed
-        
-
-if __name__ == '__main__':
-    import threading, atexit
-    
-    sock = RPCClientSocket()
-    
-    class Server1(RPCServer):
-        def add(self, a, b):
-            return a + b
-    
-    server = Server1(name='some_server')
-    def process_server():
-        while server.running():
-            server._process_one()
-        print("\nserver shut down\n")
-    serve_thread = threading.Thread(target=process_server, daemon=True)
-    serve_thread.start()
-    
-    client = sock.get_client('some_server')
-    atexit.register(client.close)
-    
-    time.sleep(0.2)
-    fut = client.add(7, 5)
-    assert fut.result() == 12
-    
-    try:
-        client.add(7, 'x').result()
-    except RemoteCallException as err:
-        if err.type_str != 'TypeError':
-            raise
-    
-    try:
-        client.fn().result()
-    except RemoteCallException as err:
-        if err.type_str != 'AttributeError':
-            raise
-    
-    
-    

--- a/pyacq/core/tests/test_rpc.py
+++ b/pyacq/core/tests/test_rpc.py
@@ -31,12 +31,24 @@ def test_rpc():
     except RemoteCallException as err:
         if err.type_str != 'TypeError':
             raise
+    else:
+        raise AssertionError('should have raised TypeError')
 
     try:
         client.fn().result()
     except RemoteCallException as err:
         if err.type_str != 'AttributeError':
             raise
+    else:
+        raise AssertionError('should have raised AttributeError')
+
+    # test timeouts
+    try:
+        client.sleep(0.2).result(timeout=0.01)
+    except TimeoutError:
+        pass
+    else:
+        raise AssertionError('should have raised TimeoutError')
 
     # test result order
     a = client.add(1, 2)
@@ -54,6 +66,8 @@ def test_rpc():
     assert a.result() == 3
     assert c.result() == 11
 
+
+    
 
 if __name__ == '__main__':
     test_rpc()

--- a/pyacq/core/tests/test_rpc.py
+++ b/pyacq/core/tests/test_rpc.py
@@ -66,8 +66,19 @@ def test_rpc():
     assert a.result() == 3
     assert c.result() == 11
 
-
+    # test multiple clients sharing one socket
+    server2 = Server1(name='some_server2', addr='tcp://*:5153')
+    serve_thread2 = threading.Thread(target=server2.run_forever, daemon=True)
+    serve_thread2.start()
     
+    client3 = RPCClient('some_server2', 'tcp://localhost:5153',
+                        socket=client2._socket)
+    
+    a = client2.add(1, 2)
+    b = client3.add(3, 4)
+    assert b.result() == 7
+    assert a.result() == 3
+
 
 if __name__ == '__main__':
     test_rpc()

--- a/pyacq/core/tests/test_rpc.py
+++ b/pyacq/core/tests/test_rpc.py
@@ -11,19 +11,10 @@ def test_rpc():
     server = Server1(name='some_server', addr='tcp://*:5152')
     serve_thread = threading.Thread(target=server.run_forever, daemon=True)
     serve_thread.start()
-
+    
     client = RPCClient('some_server', 'tcp://localhost:5152')
     atexit.register(client.close)
     
-    #mon = client._socket.socket.get_monitor_socket()
-    #def monitor():
-        #while mon.poll():
-            #evt = zmq.utils.monitor.recv_monitor_message(mon)
-            #print("MON:", evt)
-    #mon_thread = threading.Thread(target=monitor, daemon=True)
-    #mon_thread.start()
-            
-
     time.sleep(0.4)
     fut = client.add(7, 5)
     assert fut.result() == 12

--- a/pyacq/core/tests/test_rpc.py
+++ b/pyacq/core/tests/test_rpc.py
@@ -7,6 +7,8 @@ def test_rpc():
     class Server1(RPCServer):
         def add(self, a, b):
             return a + b
+        def sleep(self, t):
+            time.sleep(t)
 
     server = Server1(name='some_server', addr='tcp://*:5152')
     serve_thread = threading.Thread(target=server.run_forever, daemon=True)
@@ -15,10 +17,15 @@ def test_rpc():
     client = RPCClient('some_server', 'tcp://localhost:5152')
     atexit.register(client.close)
     
-    time.sleep(0.4)
+    # test call / return
     fut = client.add(7, 5)
     assert fut.result() == 12
 
+    fut = client.sleep(0.1)
+    assert not fut.done()
+    assert fut.result() is None
+
+    # Test remote exception raising
     try:
         client.add(7, 'x').result()
     except RemoteCallException as err:
@@ -31,7 +38,21 @@ def test_rpc():
         if err.type_str != 'AttributeError':
             raise
 
+    # test result order
+    a = client.add(1, 2)
+    b = client.add(3, 4)
+    assert b.result() == 7
+    assert a.result() == 3
 
+    # test multiple clients per server
+    client2 = RPCClient('some_server', 'tcp://localhost:5152')
+    
+    a = client2.add(1, 2)
+    b = client.add(3, 4)
+    c = client2.add(5, 6)
+    assert b.result() == 7
+    assert a.result() == 3
+    assert c.result() == 11
 
 
 if __name__ == '__main__':

--- a/pyacq/core/tests/test_rpc.py
+++ b/pyacq/core/tests/test_rpc.py
@@ -72,7 +72,7 @@ def test_rpc():
     serve_thread2.start()
     
     client3 = RPCClient('some_server2', 'tcp://localhost:5153',
-                        socket=client2._socket)
+                        shared_client=client2)
     
     a = client2.add(1, 2)
     b = client3.add(3, 4)

--- a/pyacq/core/tests/test_rpc.py
+++ b/pyacq/core/tests/test_rpc.py
@@ -1,0 +1,39 @@
+import threading, atexit, time
+from pyacq.core.rpc import RPCClientSocket, RemoteCallException, RPCServer
+
+
+def test_rpc():
+    class Server1(RPCServer):
+        def add(self, a, b):
+            return a + b
+
+    server = Server1(addr='tcp://*:5152')
+    def process_server():
+        while server.running():
+            server._process_one()
+        print("\nserver shut down\n")
+    serve_thread = threading.Thread(target=process_server, daemon=True)
+    serve_thread.start()
+
+    client = sock.get_client('some_server')
+    atexit.register(client.close)
+
+    time.sleep(0.2)
+    fut = client.add(7, 5)
+    assert fut.result() == 12
+
+    try:
+        client.add(7, 'x').result()
+    except RemoteCallException as err:
+        if err.type_str != 'TypeError':
+            raise
+
+    try:
+        client.fn().result()
+    except RemoteCallException as err:
+        if err.type_str != 'AttributeError':
+            raise
+
+
+if __name__ == '__main__':
+    test_rpc()


### PR DESCRIPTION
RPC now uses router-router zmq sockets.

* multiple clients can share a socket, as before
* a single server may have multiple clients
* servers now bind(), clients connect()
* ensure connection is established before sending procedure call requests
* more documentation and unit tests