### PR TITLE
Remote host

### DIFF
--- a/pyacq/core/host.py
+++ b/pyacq/core/host.py
@@ -1,5 +1,6 @@
 import re
 import logging
+import atexit
 
 from .rpc import ProcessSpawner, RPCServer
 from .nodegroup import NodeGroup
@@ -33,6 +34,8 @@ class Host(object):
             server['host'] = self
             if poll_procs:
                 self.timer = server.start_timer(self.check_spawners, interval=1.0)
+                
+        atexit.register(self.close_all_nodegroups)
 
     def create_nodegroup(self, name, manager=None, qt=True, **kwds):
         """Create a new NodeGroup in a new process and return a proxy to it.

--- a/pyacq/core/host.py
+++ b/pyacq/core/host.py
@@ -59,7 +59,7 @@ class Host(object):
         sp._nodegroup = rng.NodeGroup(host=self, manager=manager)
         
         # publish so others can easily connect to the nodegroup
-        sp.client['nodegroup'] = ps._nodegroup
+        sp.client['nodegroup'] = sp._nodegroup
         
         sp._manager = manager
         self.spawners.append(sp)

--- a/pyacq/core/host.py
+++ b/pyacq/core/host.py
@@ -1,3 +1,5 @@
+import re
+
 from .rpc import ProcessSpawner, RPCServer
 from .nodegroup import NodeGroup
 
@@ -42,7 +44,9 @@ class Host(object):
             
         All extra keyword arguments are passed to `ProcessSpawner()`.
         """
-        ps = ProcessSpawner(name=name, qt=qt, **kwds)
+        server = RPCServer.get_server()
+        addr = re.sub(r':\d+$', ':*', server.address.decode())
+        ps = ProcessSpawner(name=name, qt=qt, address=addr, **kwds)
         rng = ps.client._import('pyacq.core.nodegroup')
         
         # create nodegroup in remote process

--- a/pyacq/core/host.py
+++ b/pyacq/core/host.py
@@ -21,13 +21,15 @@ class Host(object):
     
     def __init__(self, name):
         self.name = name
-        self.spawners = set()
+        self.spawners = []
         
         # Publish this object so we can easily retrieve it from any other
         # machine.
         server = RPCServer.get_server()
         if server is not None:
             server['host'] = self
+            
+        self.timer = server.start_timer(self.check_spawners, interval=1.0)
 
     def create_nodegroup(self, name, manager=None, qt=True, **kwds):
         """Create a new NodeGroup in a new process and return a proxy to it.
@@ -56,7 +58,7 @@ class Host(object):
         ps.client['nodegroup'] = ps._nodegroup
         
         ps._manager = manager
-        self.spawners.add(ps)
+        self.spawners.append(ps)
         return ps._nodegroup
 
     def close_all_nodegroups(self, force=False):
@@ -67,4 +69,4 @@ class Host(object):
                 sp.kill()
             else:
                 sp.stop()
-        self.spawners = set()
+        self.spawners = []

--- a/pyacq/core/manager.py
+++ b/pyacq/core/manager.py
@@ -187,7 +187,7 @@ class Manager(object):
             if ng in self._closed_nodegroups:
                 continue
             try:
-                ng.close()
+                ng.close(_sync='off')
             except RuntimeError:
                 # If the server has already disconnected, then no need to close.
                 cli = RPCClient.get_client(ng._rpc_addr)

--- a/pyacq/core/manager.py
+++ b/pyacq/core/manager.py
@@ -165,6 +165,10 @@ class Manager(object):
         ng = host.create_nodegroup(name=name, manager=self, qt=qt, **kwds)
         self.nodegroups[name] = ng
         return ng
+
+    def nodegroup_closed(self, ng):
+        # Called by host when it detects that a nodegroup's process has exited.
+        pass
     
     def list_nodegroups(self):
         return list(self.nodegroups.values())

--- a/pyacq/core/manager.py
+++ b/pyacq/core/manager.py
@@ -75,6 +75,7 @@ class Manager(object):
         logger.info('Creating new Manager..')
         self.hosts = {}  # addr:Host
         self.nodegroups = {}  # name:Nodegroup
+        self._closed_nodegroups = set()
         
         # Host used for starting nodegroups on the local machine
         self.default_host = Host('default_host')
@@ -168,7 +169,7 @@ class Manager(object):
 
     def nodegroup_closed(self, ng):
         # Called by host when it detects that a nodegroup's process has exited.
-        pass
+        self._closed_nodegroups.add(ng)
     
     def list_nodegroups(self):
         return list(self.nodegroups.values())
@@ -183,6 +184,8 @@ class Manager(object):
 
     def close_all_nodegroups(self):
         for ng in self.nodegroups.values():
+            if ng in self._closed_nodegroups:
+                continue
             try:
                 ng.close()
             except RuntimeError:

--- a/pyacq/core/rpc/bootstrap.py
+++ b/pyacq/core/rpc/bootstrap.py
@@ -1,0 +1,73 @@
+"""Script for bootstrapping new processes created with ProcessSpawner.
+"""
+import zmq
+import time
+import sys
+import json
+import traceback
+import faulthandler
+import logging
+
+# Load configuration options for this process from stdin
+conf = json.loads(sys.stdin.read())
+
+# Set up some basic debugging support before importing pyacq
+faulthandler.enable()
+logger = logging.getLogger()
+logger.level = conf['loglevel']
+
+import pyacq
+from pyacq.core.rpc import log
+
+# Start QApplication if requested
+if conf['qt']:
+    import pyqtgraph as pg
+    app = pg.mkQApp()
+    app.setQuitOnLastWindowClosed(False)
+
+# Set up log record forwarding
+if conf['procname'] is not None:
+    log.set_process_name(conf['procname'])
+if conf['logaddr'] is not None:
+    log.set_logger_address(conf['logaddr'].encode())
+
+# Also send unhandled exceptions to log server
+log.log_exceptions()
+
+logger.info("New process {procname} {class_name}({args}) log_addr:{logaddr} log_level:{loglevel}".format(**conf))
+
+# Open a socket to parent process to inform it of the new RPC server address
+bootstrap_sock = zmq.Context.instance().socket(zmq.PAIR)
+bootstrap_sock.connect(conf['bootstrap_addr'].encode())
+bootstrap_sock.linger = 1000
+
+# Create RPC server
+try:
+    # Create server
+    server_class = getattr(pyacq, conf['class_name'])
+    server = server_class(**conf['args'])
+    status = {'address': server.address.decode()}
+except:
+    logger.error("Error starting {class_name} with args: {args}:".format(**conf))
+    status = {'error': traceback.format_exception(*sys.exc_info())}
+    
+# Report server status to spawner
+start = time.time()
+while time.time() < start + 10.0:
+    # send status repeatedly until spawner gives a reply.
+    bootstrap_sock.send_json(status)
+    try:
+        bootstrap_sock.recv(zmq.NOBLOCK)
+        break
+    except zmq.error.Again:
+        time.sleep(0.01)
+        continue
+
+bootstrap_sock.close()
+
+# Run server until heat death of universe
+if 'address' in status:
+    server.run_forever()
+    
+if conf['qt']:
+    app.exec_()

--- a/pyacq/core/rpc/bootstrap.py
+++ b/pyacq/core/rpc/bootstrap.py
@@ -10,6 +10,12 @@ import logging
 
 # Load configuration options for this process from stdin
 conf = json.loads(sys.stdin.read())
+# process name is passed in argv to make it easier to identify processes
+# from the outside.
+if len(sys.argv) > 1:
+    conf['procname'] = sys.argv[1]
+else:
+    conf['procname'] = None
 
 # Set up some basic debugging support before importing pyacq
 faulthandler.enable()

--- a/pyacq/core/rpc/client.py
+++ b/pyacq/core/rpc/client.py
@@ -273,6 +273,10 @@ class RPCClient(object):
                     self._read_and_process_one(timeout=0)
                 elif len(socks) > 0: 
                     server = RPCServer.get_server()
+                    if server is None:
+                        # this can happen after server has unregistered itself 
+                        # at exit
+                        continue
                     server._read_and_process_one()
                 
     def _read_and_process_one(self, timeout):

--- a/pyacq/core/rpc/client.py
+++ b/pyacq/core/rpc/client.py
@@ -108,9 +108,6 @@ class RPCClient(object):
         self.establishing_connect = False
         self._disconnected = False
 
-        # Proxies we have received from other machines. 
-        self.proxies = {}
-
         # For unserializing results returned from servers. This cannot be
         # used to send proxies of local objects unless there is also a server
         # for this thread..
@@ -208,7 +205,7 @@ class RPCClient(object):
 
     def delete(self, obj, **kwds):
         assert obj._rpc_addr == self.address
-        return self.send('delete', opts={'obj_id': obj._obj_id}, **kwds)
+        return self.send('delete', opts={'obj_id': obj._obj_id, 'ref_id': obj._ref_id}, **kwds)
 
     def __getitem__(self, name):
         return self.send('getitem', opts={'name': name}, sync='sync')

--- a/pyacq/core/rpc/processspawner.py
+++ b/pyacq/core/rpc/processspawner.py
@@ -50,7 +50,7 @@ bootstrap_sock.linger = 1000
 try:
     # Create server
     server = {class_name}({args})
-    status = {{'addr': server.address.decode()}}
+    status = {{'address': server.address.decode()}}
 except:
     logger.error("Error starting {class_name} with args: {args}:")
     status = {{'error': traceback.format_exception(*sys.exc_info())}}
@@ -70,7 +70,7 @@ while time.time() < start + 10.0:
 bootstrap_sock.close()
 
 # Run server until heat death of universe
-if 'addr' in status:
+if 'address' in status:
     server.run_forever()
     
 if {qt}:
@@ -88,7 +88,7 @@ class ProcessSpawner(object):
     ----------
     name : str | None
         Optional process name that will be assigned to all remote log records.
-    addr : str
+    address : str
         ZMQ socket address that the new process's RPCServer will bind to.
         Default is 'tcp://*:*'.
     qt : bool
@@ -104,11 +104,11 @@ class ProcessSpawner(object):
     executable : str | None
         Optional python executable to invoke. The default value is `sys.executable`.
     """
-    def __init__(self, name=None, addr="tcp://*:*", qt=False, log_addr=None, 
+    def __init__(self, name=None, address="tcp://*:*", qt=False, log_addr=None, 
                  log_level=None, executable=None):
         #logger.warn("Spawning process: %s %s %s", name, log_addr, log_level)
         assert qt in (True, False)
-        assert isinstance(addr, (str, bytes))
+        assert isinstance(address, (str, bytes))
         assert name is None or isinstance(name, str)
         assert log_addr is None or isinstance(log_addr, (str, bytes)), "log_addr must be str or None; got %r" % log_addr
         if log_addr is None:
@@ -130,7 +130,7 @@ class ProcessSpawner(object):
         
         # Spawn new process
         class_name = 'QtRPCServer' if qt else 'RPCServer'
-        args = "addr='%s'" % addr
+        args = "address='%s'" % address
         bootstrap = bootstrap_template.format(class_name=class_name, args=args,
                                               bootstrap_addr=bootstrap_addr,
                                               loglevel=log_level, qt=str(qt),
@@ -170,9 +170,9 @@ class ProcessSpawner(object):
         bootstrap_sock.send(b'OK')
         bootstrap_sock.close()
         
-        if 'addr' in status:
-            self.addr = status['addr']
-            self.client = RPCClient(self.addr.encode())
+        if 'address' in status:
+            self.address = status['address']
+            self.client = RPCClient(self.address.encode())
         else:
             err = ''.join(status['error'])
             self.kill()

--- a/pyacq/core/rpc/processspawner.py
+++ b/pyacq/core/rpc/processspawner.py
@@ -75,18 +75,19 @@ class ProcessSpawner(object):
             loglevel=log_level,
             logaddr=log_addr.decode() if log_addr is not None else None,
             qt=qt,
-            procname=name,
         )
-        
-        bootstrap_file = os.path.join(os.path.dirname(__file__), 'bootstrap.py')
         
         if executable is None:
             executable = sys.executable
 
+        cmd = (executable, '-m', 'pyacq.core.rpc.bootstrap')
+        if name is not None:
+            cmd = cmd + (name,)
+
         if log_addr is not None:
             # start process with stdout/stderr piped
-            self.proc = subprocess.Popen((executable, bootstrap_file), stdin=subprocess.PIPE,
-                                         stderr=subprocess.PIPE, stdout=subprocess.PIPE)
+            self.proc = subprocess.Popen(cmd, stdin=subprocess.PIPE, stderr=subprocess.PIPE,
+                                         stdout=subprocess.PIPE)
             
             self.proc.stdin.write(json.dumps(bootstrap_conf).encode())
             self.proc.stdin.close()
@@ -104,7 +105,7 @@ class ProcessSpawner(object):
             
         else:
             # don't intercept stdout/stderr
-            self.proc = subprocess.Popen((executable, bootstrap_file), stdin=subprocess.PIPE)
+            self.proc = subprocess.Popen(cmd, stdin=subprocess.PIPE)
             self.proc.stdin.write(json.dumps(bootstrap_conf).encode())
             self.proc.stdin.close()
             

--- a/pyacq/core/rpc/processspawner.py
+++ b/pyacq/core/rpc/processspawner.py
@@ -141,8 +141,11 @@ class ProcessSpawner(object):
 
         if log_addr is not None:
             # start process with stdout/stderr piped
-            self.proc = subprocess.Popen((executable, '-c', bootstrap), 
+            self.proc = subprocess.Popen((executable,), stdin=subprocess.PIPE,
                                          stderr=subprocess.PIPE, stdout=subprocess.PIPE)
+            
+            self.proc.stdin.write(bootstrap.encode())
+            self.proc.stdin.close()
             
             # create a logger for handling stdout/stderr and forwarding to log server
             self.logger = logging.getLogger(__name__ + '.' + str(id(self)))

--- a/pyacq/core/rpc/processspawner.py
+++ b/pyacq/core/rpc/processspawner.py
@@ -73,7 +73,7 @@ class ProcessSpawner(object):
             args=args,
             bootstrap_addr=bootstrap_addr.decode(),
             loglevel=log_level,
-            logaddr=log_addr.decode(), 
+            logaddr=log_addr.decode() if log_addr is not None else None,
             qt=qt,
             procname=name,
         )
@@ -104,7 +104,9 @@ class ProcessSpawner(object):
             
         else:
             # don't intercept stdout/stderr
-            self.proc = subprocess.Popen((executable, '-c', bootstrap))
+            self.proc = subprocess.Popen((executable, bootstrap_file), stdin=subprocess.PIPE)
+            self.proc.stdin.write(json.dumps(bootstrap_conf).encode())
+            self.proc.stdin.close()
             
         logger.info("Spawned process: %d", self.proc.pid)
         

--- a/pyacq/core/rpc/processspawner.py
+++ b/pyacq/core/rpc/processspawner.py
@@ -129,9 +129,13 @@ class ProcessSpawner(object):
         atexit.register(self.stop)
         
     def wait(self):
-        self.proc.wait()
+        """Wait for the process to exit and return its return code.
+        """
+        return self.proc.wait()
 
     def kill(self):
+        """Kill the spawned process immediately.
+        """
         if self.proc.poll() is not None:
             return
         logger.info("Kill process: %d", self.proc.pid)
@@ -139,12 +143,20 @@ class ProcessSpawner(object):
         self.proc.wait()
 
     def stop(self):
+        """Stop the spawned process by asking its RPC server to close.
+        """
         if self.proc.poll() is not None:
             return
         logger.info("Close process: %d", self.proc.pid)
         closed = self.client.close_server()
         assert closed is True, "Server refused to close. (reply: %s)" % closed
         self.proc.wait()
+
+    def poll(self):
+        """Return the spawned process's return code, or None if it has not
+        exited yet.
+        """
+        return self.proc.poll()
 
 
 class PipePoller(threading.Thread):

--- a/pyacq/core/rpc/proxy.py
+++ b/pyacq/core/rpc/proxy.py
@@ -73,7 +73,7 @@ class ObjectProxy(object):
             _type_str=type_str,
             _attributes=attributes,
             _parent_proxy=None,
-            _hash=(rpc_addr, obj_id, attributes),
+            _hash=hash((rpc_addr, obj_id, attributes)),
             # identify local client/server instances this proxy belongs to
             _client_=None,
             _server_=None,
@@ -279,8 +279,8 @@ class ObjectProxy(object):
         """Override __hash__ because we need to avoid comparing remote and local
         hashes.
         """
-        return id(self)
-
+        #return id(self)
+        return self._hash
     
     # Explicitly proxy special methods. Is there a better way to do this??
     

--- a/pyacq/core/rpc/server.py
+++ b/pyacq/core/rpc/server.py
@@ -13,6 +13,7 @@ from pyqtgraph.Qt import QtCore, QtGui
 
 from .serializer import all_serializers
 from .proxy import ObjectProxy
+from .timer import Timer
 from . import log
 
 
@@ -89,8 +90,10 @@ class RPCServer(object):
         This static method fails if another server is already registered for
         this thread.
         """
-        assert srv._thread is None, "Server has already been registered."
         key = threading.current_thread().ident
+        if srv._thread == key:
+            return
+        assert srv._thread is None, "Server has already been registered."
         with RPCServer.servers_by_thread_lock:
             if key in RPCServer.servers_by_thread:
                 raise KeyError("An RPCServer is already running in this thread.")

--- a/pyacq/core/rpc/server.py
+++ b/pyacq/core/rpc/server.py
@@ -421,6 +421,12 @@ class RPCServer(object):
             if isinstance(obj, typ):
                 return obj
         return self.get_proxy(obj)
+    
+    def start_timer(self, callback, interval, **kwds):
+        kwds.setdefault('start', True)
+        if not isinstance(callback, ObjectProxy):
+            callback = self.get_proxy(callback)
+        return Timer(callback, interval, **kwds)
 
 
 class QtRPCServer(RPCServer):

--- a/pyacq/core/rpc/server.py
+++ b/pyacq/core/rpc/server.py
@@ -423,6 +423,16 @@ class RPCServer(object):
         return self.get_proxy(obj)
     
     def start_timer(self, callback, interval, **kwds):
+        """Start a timer that invokes *callback* at regular intervals.
+        
+        Parameters
+        ----------
+        callback : callable
+            Callable object to invoke. This must either be an ObjectProxy or
+            an object that is safe to call from the server's thread.
+        interval : float
+            Minimum time to wait between callback invocations (start to start).
+        """
         kwds.setdefault('start', True)
         if not isinstance(callback, ObjectProxy):
             callback = self.get_proxy(callback)

--- a/pyacq/core/rpc/server.py
+++ b/pyacq/core/rpc/server.py
@@ -26,7 +26,7 @@ class RPCServer(object):
     ----------
     name : str
         Name used to identify this server.
-    addr : URL
+    address : URL
         Address for RPC server to bind to.
 
     Basic usage::
@@ -115,7 +115,7 @@ class RPCServer(object):
         srv = RPCServer.get_server()
         return RPCClient.get_client(srv.address)
         
-    def __init__(self, addr="tcp://*:*"):
+    def __init__(self, address="tcp://*:*"):
         self._socket = zmq.Context.instance().socket(zmq.ROUTER)
         
         # socket will continue attempting to deliver messages up to 5 sec after
@@ -123,7 +123,7 @@ class RPCServer(object):
         # on exit)
         self._socket.linger = 5000
         
-        self._socket.bind(addr)
+        self._socket.bind(address)
         self.address = self._socket.getsockopt(zmq.LAST_ENDPOINT)
         self._closed = False
         
@@ -432,13 +432,13 @@ class QtRPCServer(RPCServer):
     
     Parameters
     ----------
-    addr : str
+    address : str
         ZMQ address to listen on. Default is "tcp://*:*".
     quit_on_close : bool
         If True, then call `QApplication.quit()` when the server is closed. 
     """
-    def __init__(self, addr="tcp://*:*", quit_on_close=True):
-        RPCServer.__init__(self, addr)
+    def __init__(self, address="tcp://*:*", quit_on_close=True):
+        RPCServer.__init__(self, address)
         self.quit_on_close = quit_on_close
         self.poll_thread = QtPollThread(self)
         

--- a/pyacq/core/rpc/tests/test_rpc.py
+++ b/pyacq/core/rpc/tests/test_rpc.py
@@ -86,6 +86,10 @@ def test_rpc():
     assert obj == obj2
     assert obj._obj_id == obj2._obj_id
     assert obj._ref_id != obj2._ref_id    
+
+    # check hashability
+    assert obj in {obj2: None}
+    assert obj in set([obj2])
     
     logger.info("-- Test call with sync return --")
     add = obj.add

--- a/pyacq/core/rpc/tests/test_rpc.py
+++ b/pyacq/core/rpc/tests/test_rpc.py
@@ -81,6 +81,12 @@ def test_rpc():
     obj = client['my_object']
     assert isinstance(obj, ObjectProxy)
     
+    # check equality with duplicate proxy
+    obj2 = client['my_object']
+    assert obj == obj2
+    assert obj._obj_id == obj2._obj_id
+    assert obj._ref_id != obj2._ref_id    
+    
     logger.info("-- Test call with sync return --")
     add = obj.add
     assert isinstance(add, ObjectProxy)

--- a/pyacq/core/rpc/timer.py
+++ b/pyacq/core/rpc/timer.py
@@ -1,0 +1,57 @@
+import time
+import threading
+
+
+class Timer(threading.Thread):
+    """Thread for making scheduled RPC calls.
+    """
+    def __init__(self, callback, interval, limit=None, start=False):
+        threading.Thread.__init__(self, daemon=True)
+        self.callback = callback
+        self.interval = float(interval)
+        self.limit = limit
+        self._last_call_time = None
+        self._call_count = 0
+        self._lock = threading.Lock()
+        
+        if start:
+            self.start()
+            
+    def start(self):
+        with self._lock:
+            self.running = True
+            self._last_call_time = None
+            self._call_count = 0
+        
+        if self.is_alive():
+            return
+        else:
+            self.start()
+        
+    def stop(self):
+        with self._lock:
+            self.running = False
+        
+    def run(self):
+        try:
+            if self._last_call_time is None:
+                sleep_time = 0
+            else:
+                sleep_time = self.interval - (time.perf_counter() - self._last_call_time)
+            
+            if sleep_time > 0:
+                time.sleep(sleep_time)
+                
+            with self._lock:
+                if not self.running:
+                    return
+            
+            self.callback()
+            
+            with self._lock:
+                self._call_count += 1
+                if self._call_count >= self.limit:
+                    return
+        finally:
+            with self._lock:
+                self.running = False

--- a/pyacq/core/tests/test_manager.py
+++ b/pyacq/core/tests/test_manager.py
@@ -38,6 +38,12 @@ def test_manager():
     ng1.remove_node(n1)
     assert ng1.list_nodes() == []
 
+    # Need to close manager here because otherwise atexit hooks will kill the
+    # host, which results in the manager complaining that it was unable to
+    # kill the nodegroup. In real situations, we do not expect the host to
+    # disappear before the manager does. 
+    mgr.close()
+
 
 def create_some_node_group(man):
     nodegroups = []
@@ -77,7 +83,6 @@ def test_close_manager_explicit():
         ng.stop_all_nodes()
     
     man.close()
-    #time.sleep(2.)
 
 
 #@pytest.mark.skipif(True, reason='atexit not work at travis')

--- a/tools/host_server.py
+++ b/tools/host_server.py
@@ -20,8 +20,9 @@ if not re.match(r'tcp://(\*|([0-9\.]+)):(\*|[0-9]+)', address):
     sys.exit(-1)
 
 
-host = Host(name=socket.gethostname())
 server = RPCServer(address)
+server.run_lazy()
+host = Host(name=socket.gethostname(), poll_procs=True)
 server['host'] = host
 print("Running server at: %s" % server.address.decode())
 

--- a/tools/host_server.py
+++ b/tools/host_server.py
@@ -1,0 +1,32 @@
+import os, sys, re, socket
+from pyacq.core.host import Host
+from pyacq.core.rpc import RPCServer
+
+usage = """Usage:
+    python host_server.py [address]
+
+# Examples:
+python host_server.py tcp://10.0.0.100:5000
+python host_server.py tcp://10.0.0.100:*
+"""
+
+if len(sys.argv) == 2:
+    address = sys.argv[1]
+else:
+    address = ''
+    
+if not re.match(r'tcp://(\*|([0-9\.]+)):(\*|[0-9]+)', address):
+    sys.stderr.write(usage)
+    sys.exit(-1)
+
+
+host = Host(name=socket.gethostname())
+server = RPCServer(address)
+server['host'] = host
+print("Running server at: %s" % server.address.decode())
+
+try:
+    server.run_forever()
+except KeyboardInterrupt:
+    sys.stderr.write("Caught keyboard interrupt, shutting down..\n")
+    server.close()

--- a/tools/mk_virtualenv.sh
+++ b/tools/mk_virtualenv.sh
@@ -1,7 +1,7 @@
 # set up new virtualenv with all ppip-installable packages
 virtualenv --python=python3.4 venv
 . venv/bin/activate
-pip install pyzmq pytest numpy scipy pyqtgraph vispy colorama msgpack-python pyaudio
+pip install pyzmq pytest numpy scipy pyqtgraph vispy colorama msgpack-python pyaudio blosc
 
 # copy sip and pyqt from system packages (these are not pip installable)
 cp -r /usr/lib/python3/dist-packages/sip* venv/lib/python3.4/site-packages/

--- a/tools/mk_virtualenv.sh
+++ b/tools/mk_virtualenv.sh
@@ -1,0 +1,11 @@
+# set up new virtualenv with all ppip-installable packages
+virtualenv --python=python3.4 venv
+. venv/bin/activate
+pip install pyzmq pytest numpy scipy pyqtgraph vispy colorama msgpack-python pyaudio
+
+# copy sip and pyqt from system packages (these are not pip installable)
+cp -r /usr/lib/python3/dist-packages/sip* venv/lib/python3.4/site-packages/
+cp -r /usr/lib/python3/dist-packages/PyQt4/ venv/lib/python3.4/site-packages/
+
+# install pyacq to virtual env
+python setup.py develop


### PR DESCRIPTION
This gets operation with real remote Host instances working smoothly.

* Adds a `tools/host_server.py` script for starting host servers
* Hosts poll their nodegroups and inform the manager if a nodegroup exits
* Numerous bugfixes related to exiting gracefully under various conditions
* Debugging cleanups--logging corrections, no more passing long python scripts as CLI arguments
