### PR TITLE
Make pyaudio_oscope_local.py example repeatable

### DIFF
--- a/examples/pyaudio_oscope_local.py
+++ b/examples/pyaudio_oscope_local.py
@@ -54,3 +54,7 @@ if __name__ == '__main__':
     import sys
     if sys.flags.interactive == 0:
         app.exec_()
+
+# stop and close pyaudio node to properly close pyaudio
+dev.stop()
+dev.close()

--- a/pyacq/core/stream/stream.py
+++ b/pyacq/core/stream/stream.py
@@ -297,9 +297,12 @@ class InputStream(object):
         This closes the socket.
         
         """
-        self.receiver.close()
-        self.socket.close()
-        del self.socket
+        try:
+            self.receiver.close()
+            self.socket.close()
+            del self.socket
+        except AttributeError:
+            pass
     
     def __getitem__(self, *args):
         """Return a data slice from the RingBuffer attached to this InputStream.

--- a/pyacq/devices/audio_pyaudio.py
+++ b/pyacq/devices/audio_pyaudio.py
@@ -167,7 +167,9 @@ class PyAudio(Node):
     def _close(self):
         self.audiostream.close()
         self.pa.terminate()
-        del self.thread
+        if self.output_device_index is not None:
+            del (self.thread)
+
 
     def _audiocallback(self, in_data, frame_count, time_info, status):
         #~ print('audiocallback', len(self.out_queue))


### PR DESCRIPTION
# pyaudio_oscope_local.py - main: stop and close pyaudio node to properly close pyaudio
# Otherwise, an error appears in succesive executions: 
# ValueError: Input not supported: channels=1 samplerate=44100.0 device_id=2

# audio_pyaudio.py - PyAudio._close
# Condition added to address the fact that thread is only created when self.output_device_index is not None
# otherwise: AttributeError: thread

# stream.py - InputStream.close
# There are situations in which input does not need to be connected (namely audio_pyaudio node) and hence, trying to access for closing produces an error
#  AttributeError: 'InputStream' object has no attribute 'receiver'
#  Try...catch added around- self.receiver.close()
# same for socket
# Evaluate if the same applies to OutputStream.close