### PR TITLE
patch to pass devices unit testing

### DIFF
--- a/pyacq/devices/tests/test_eeg_openBCI.py
+++ b/pyacq/devices/tests/test_eeg_openBCI.py
@@ -12,6 +12,7 @@ from pyqtgraph.Qt import QtCore, QtGui
 
 import pytest
 
+@pytest.mark.skip(reason="need Device")
 @pytest.mark.skipif(not HAVE_PYSERIAL, reason='no have pyserial')
 def test_eeg_OpenBCI():
     # in main App


### PR DESCRIPTION
simple pytest skip to avoid runing unit tests on device tests.
Maybe a general flag could be used to know if the tests runs from travis/appveyor, to skip device testing properly? 

something inspired by
@pytest.mark.skipIf("TRAVIS" in os.environ and os.environ["TRAVIS"] == "true", "Skipping this test on Travis CI.")